### PR TITLE
Alignment to cats conventions.

### DIFF
--- a/src/main/scala/spire/ops/Ops.scala
+++ b/src/main/scala/spire/ops/Ops.scala
@@ -473,8 +473,8 @@ trait DefaultOperatorNames {
     ("$less$eq", "lteqv"),
 
     // Semigroup (|+| |-|)
-    ("$bar$plus$bar", "op"),
-    ("$bar$minus$bar", "opInverse"),
+    ("$bar$plus$bar", "combine"),
+    ("$bar$minus$bar", "remove"),
 
     // Ring (unary_- + - * **)
     ("unary_$minus", "negate"),


### PR DESCRIPTION
Now algebra and spire follow cats-kernel convention, and thus the default names for `|+|` and `|-|` should be changed as follows:
```scala
      ("$bar$plus$bar", "combine"),
      ("$bar$minus$bar", "remove")
```
... or, imho, the default operator names should be removed from machinist except for the most uncontroversial (`plus`, `minus` ...).