### PR TITLE
Add Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -194,4 +194,8 @@ All code is available to you under the MIT license, available at
 http://opensource.org/licenses/mit-license.php as well as in the
 COPYING file.
 
+### Code of Conduct
+
+See the [Code of Conduct](CODE_OF_CONDUCT.md)
+
 Copyright Erik Osheim and Tom Switzer 2011-2018.


### PR DESCRIPTION
Typelevel is [switching to the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html), and encouraging all member projects to follow.