### PR TITLE
Update to Scala 2.13.0-RC3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
 - 2.10.7
 - 2.11.12
 - 2.12.8
-- 2.13.0-RC2
+- 2.13.0-RC3
 jdk:
 - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val machinistSettings = Seq(
   homepage := Some(url("http://github.com/typelevel/machinist")),
 
   scalaVersion := Scala212,
-  crossScalaVersions := Seq("2.10.7", Scala211, Scala212, "2.13.0-RC2"),
+  crossScalaVersions := Seq("2.10.7", Scala211, Scala212, "2.13.0-RC3"),
 
   scalacOptions ++= Seq(
     "-feature",


### PR DESCRIPTION
We can just publish this as an 0.6.8, since there are no other changes since then.

r? @larsrh 